### PR TITLE
fix: correct sunset label in sunrise-sunset tile

### DIFF
--- a/sunrise-sunset/src/sunrise-sunset.html
+++ b/sunrise-sunset/src/sunrise-sunset.html
@@ -32,7 +32,7 @@
         <div class="value"></div>
       </div>
       <div id="sunset">
-        <div class="label">Sunrise</div>
+        <div class="label">Sunset</div>
         <div class="value"></div>
       </div>
     </div>

--- a/sunrise-sunset/sunrise-sunset.html
+++ b/sunrise-sunset/sunrise-sunset.html
@@ -31,7 +31,7 @@
         <div class="value"></div>
       </div>
       <div id="sunset">
-        <div class="label">Sunrise</div>
+        <div class="label">Sunset</div>
         <div class="value"></div>
       </div>
     </div>


### PR DESCRIPTION
This PR fixes the labeling issue in the sunrise-sunset custom tile where both divs were incorrectly showing "Sunrise" labels.

## Changes
- Fixed sunset div label from "Sunrise" to "Sunset" in both HTML files
- Updated `sunrise-sunset/sunrise-sunset.html`
- Updated `sunrise-sunset/src/sunrise-sunset.html`

Fixes #2

Generated with [Claude Code](https://claude.ai/code)