### PR TITLE
feat: Add media image display tile for Thing attributes and Variables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,12 @@ myVariable.onValue(function(value) {
 const currentValue = myVariable.value;
 ```
 
+**Variable Setting Requirements**: When using VARIABLE in tile settings, you MUST specify the variable type filter:
+```json
+{"type": "VARIABLE", "name": "variable", "label": "Variable", "filters": {"type": "String"}}
+```
+Available types: "String", "Number", "Boolean"
+
 ### User Interaction Methods
 ```javascript
 // Show toast notification
@@ -223,13 +229,20 @@ Variable integration:
 {
   "schema": "0.2.0",
   "settings": [
-    {"type": "VARIABLE", "name": "variable", "label": "Variable"}
+    {
+      "type": "VARIABLE", 
+      "name": "variable", 
+      "label": "Variable",
+      "filters": {"type": "String"}
+    }
   ],
   "name": "Variable Tile"
 }
 </script>
 <!-- Do not edit above -->
 ```
+
+**Important**: VARIABLE settings MUST specify `filters.type` with one of: "String", "Number", or "Boolean".
 
 Legacy API approach (deprecated - use schema 0.2.0 for new tiles):
 ```html

--- a/media-image/README.md
+++ b/media-image/README.md
@@ -1,0 +1,43 @@
+# Media Image Display Tile
+
+This Custom Tile for SharpTools displays images from URLs stored in Thing attributes or SharpTools Variables. It's perfect for displaying dynamic images like game artwork, camera snapshots, or any other media that changes based on your smart home state.
+
+## Features
+
+- Display images from URLs stored in SharpTools Variables
+- Display images from URLs stored in Thing attributes (e.g., HomeAssistant sensors)
+- Automatic image updates when the source URL changes
+- Error handling for invalid URLs or failed image loads
+- Responsive image display that scales to fit the tile
+
+## Use Cases
+
+- Display currently playing game artwork from gaming consoles (PS5, Xbox, etc.)
+- Show album artwork from media players
+- Display camera snapshots or weather maps
+- Show any dynamic image content from your smart home devices
+
+## Configuration
+
+1. **Source Type**: Choose between Variable or Thing Attribute
+2. **Variable Mode**: Select a SharpTools Variable that contains an image URL
+3. **Thing Mode**: Select a Thing and then choose an attribute that contains an image URL
+
+## Example Setup
+
+### For HomeAssistant PS5 Game Artwork:
+1. Set Source Type to "Thing Attribute"
+2. Select your PS5 sensor Thing
+3. Select the attribute containing the game artwork URL
+
+### For SharpTools Variable:
+1. Set Source Type to "Variable"
+2. Select a Variable containing an image URL
+3. The tile will automatically update when the Variable value changes
+
+## Technical Details
+
+- Images are displayed using `object-fit: contain` to maintain aspect ratio
+- Supports all standard web image formats (PNG, JPG, GIF, WebP, etc.)
+- Includes URL validation and error handling
+- Real-time updates via SharpTools event system

--- a/media-image/media-image.html
+++ b/media-image/media-image.html
@@ -1,0 +1,164 @@
+  <script src="https://cdn.sharptools.io/js/custom-tiles.js"></script>
+
+  <div class="main-content">
+    <img id="media-image" alt="Media Image" />
+    <div id="error-message"></div>
+  </div>
+
+  <script>
+    var thing;
+    var attribute;
+    var variable;
+    
+    var imageEl = document.getElementById("media-image");
+    var errorEl = document.getElementById("error-message");
+    
+    stio.ready(function(data){
+      // Get settings from callback
+      thing = data.settings.thing;
+      attribute = data.settings.attribute;
+      variable = data.settings.variable;
+      
+      // Determine source type and initialize
+      if(variable) {
+        // Variable mode
+        if(!variable.value) {
+          return showError('Variable has no value');
+        }
+        
+        // Initialize with current value
+        updateImage(variable.value);
+        
+        // Setup value change listener
+        variable.onValue(updateImage);
+      }
+      else if(thing && attribute) {
+        // Thing mode
+        let attr = thing.attributes[attribute];
+        if(!attr) {
+          return showError('Selected attribute not available on device');
+        }
+        
+        // Initialize with current value
+        updateImage(attr.value);
+        
+        // Setup value change listener
+        attr.onValue(updateImage);
+        
+        // Subscribe to realtime updates
+        thing.subscribe(attribute);
+      }
+      else {
+        return showError('Please configure either a Variable or Thing + Attribute');
+      }
+    });
+    
+    function showError(message){
+      console.error('Media Image Tile:', message);
+      errorEl.textContent = message;
+      errorEl.style.display = 'block';
+      imageEl.style.display = 'none';
+    }
+    
+    function updateImage(url){
+      if(!url || typeof url !== 'string') {
+        return showError('Invalid or empty URL');
+      }
+      
+      // Basic URL validation
+      try {
+        new URL(url);
+      } catch(e) {
+        return showError('Invalid URL format: ' + url);
+      }
+      
+      // Clear any previous errors
+      errorEl.style.display = 'none';
+      
+      // Update image source
+      imageEl.src = url;
+      imageEl.style.display = 'block';
+      
+      // Handle image load errors
+      imageEl.onerror = function() {
+        showError('Failed to load image from URL: ' + url);
+      };
+      
+      imageEl.onload = function() {
+        console.log('Image loaded successfully:', url);
+      };
+    }
+  </script>
+
+  <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+      padding: 0;
+    }
+    
+    .main-content {
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+    }
+    
+    #media-image {
+      max-width: 100%;
+      max-height: 100%;
+      object-fit: contain;
+      display: none;
+    }
+    
+    #error-message {
+      color: #ff4444;
+      text-align: center;
+      padding: 20px;
+      display: none;
+      font-family: Arial, sans-serif;
+      font-size: 14px;
+    }
+  </style>
+
+  <!-- Do not edit below -->
+  <script type="application/json" id="tile-settings">
+  {
+    "schema": "0.2.0",
+    "settings": [
+      {
+        "type": "ENUM",
+        "name": "sourceType",
+        "label": "Source Type",
+        "values": [
+          {"label": "Variable", "value": "variable"},
+          {"label": "Thing Attribute", "value": "thing"}
+        ],
+        "default": "variable"
+      },
+      {
+        "type": "VARIABLE",
+        "name": "variable",
+        "label": "Variable (containing image URL)",
+        "filters": {"type": "String"},
+        "showIf": ["sourceType", "==", "variable"]
+      },
+      {
+        "type": "THING",
+        "name": "thing",
+        "label": "Thing",
+        "showIf": ["sourceType", "==", "thing"]
+      },
+      {
+        "type": "THING:ATTRIBUTE:NAME",
+        "name": "attribute",
+        "label": "Attribute (containing image URL)",
+        "filters": {"source": "thing"},
+        "showIf": ["sourceType", "==", "thing"]
+      }
+    ],
+    "name": "Media Image Display"
+  }
+  </script>
+  <!-- Do not edit above -->


### PR DESCRIPTION
## Summary
- Creates new media-image tile that displays images from URLs stored in SharpTools Variables or Thing attributes  
- Addresses GitHub issue #5 for displaying dynamic media content like PS5 game artwork
- Updates CLAUDE.md documentation with proper VARIABLE setting requirements

## Features
- Supports both SharpTools Variables and Thing attributes as image URL sources
- Real-time updates when source URL changes
- Proper error handling for invalid URLs and failed image loads
- Responsive image display with aspect ratio preservation

## Test plan
- [x] Created and tested tile with Lorem Picsum random images
- [x] Verified reactive updates when Variable value changes
- [x] Confirmed proper error handling for invalid URLs
- [x] Updated documentation with VARIABLE filters.type requirements

🤖 Generated with [Claude Code](https://claude.ai/code)